### PR TITLE
actually update the config

### DIFF
--- a/gitea_matrix/config.py
+++ b/gitea_matrix/config.py
@@ -15,6 +15,9 @@
 
 from mautrix.util.config import BaseProxyConfig, ConfigUpdateHelper
 
+
 class Config(BaseProxyConfig):
     def do_update(self, helper: ConfigUpdateHelper) -> None:
-        pass
+        helper.copy('webhook-secret')
+        helper.copy('send_as_notice')
+        helper.copy('time_format')


### PR DESCRIPTION
This PR implements the `do_update` function which gives the bot the ability to actually change its configuration. Without this the bot will always use its base config.